### PR TITLE
[W.I.P.] implement: send data to 3rd outlet from python

### DIFF
--- a/nt.python/help/nt.python.maxhelp
+++ b/nt.python/help/nt.python.maxhelp
@@ -38,6 +38,18 @@
 		"subpatcher_template" : "",
 		"boxes" : [ 			{
 				"box" : 				{
+					"id" : "obj-4",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 252.0, 433.0, 119.0, 22.0 ],
+					"style" : "",
+					"text" : "print from_mxj.outlet"
+				}
+
+			}
+, 			{
+				"box" : 				{
 					"id" : "obj-24",
 					"linecount" : 8,
 					"maxclass" : "comment",
@@ -181,7 +193,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 282.0, 434.0, 83.0, 20.0 ],
+					"patching_rect" : [ 163.0, 464.0, 83.0, 20.0 ],
 					"style" : "",
 					"text" : "loaded / done"
 				}
@@ -194,7 +206,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "bang" ],
-					"patching_rect" : [ 252.0, 432.0, 24.0, 24.0 ],
+					"patching_rect" : [ 186.0, 432.0, 24.0, 24.0 ],
 					"style" : ""
 				}
 
@@ -217,8 +229,8 @@
 					"id" : "obj-1",
 					"maxclass" : "newobj",
 					"numinlets" : 1,
-					"numoutlets" : 2,
-					"outlettype" : [ "", "bang" ],
+					"numoutlets" : 3,
+					"outlettype" : [ "", "bang", "" ],
 					"patching_rect" : [ 120.0, 386.0, 151.0, 22.0 ],
 					"style" : "",
 					"text" : "nt.python python_example"
@@ -230,6 +242,13 @@
 				"patchline" : 				{
 					"destination" : [ "obj-3", 0 ],
 					"source" : [ "obj-1", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-4", 0 ],
+					"source" : [ "obj-1", 2 ]
 				}
 
 			}

--- a/nt.python/help/python_example.py
+++ b/nt.python/help/python_example.py
@@ -1,5 +1,7 @@
 def multiply(a,b):
+	maxobj.outlet("mult", a, b, a * b)
 	return a * b
 
 def power(a, b):
+	maxobj.outlet("power", a, b, a ** b)
 	return a ** b

--- a/nt.python/nt.python.c
+++ b/nt.python/nt.python.c
@@ -376,7 +376,10 @@ void *ntpython_new(t_symbol *s, long argc, t_atom *argv)
         PyEval_InitThreads();
     }
     
+    PyThreadState *main_thread = PyThreadState_Get();
     x->interpreter_thread = Py_NewInterpreter();
+    PyThreadState_Swap(main_thread);
+    
     swap_interpreter(x);
     
     // Arguments

--- a/nt.python/nt.python.c
+++ b/nt.python/nt.python.c
@@ -443,6 +443,7 @@ bool is_compatible_value_type(PyObject *obj){
 }
 
 void print_functions(t_ntpython *x) {
+    swap_interpreter(x);
     PyObject *dict = PyModule_GetDict(x->t_module), *key, *value;
     Py_ssize_t pos = 0;
     
@@ -463,6 +464,7 @@ bool has_py_extention(char *scriptname){
 }
 
 void print_python_error_message(t_ntpython *x){
+    swap_interpreter(x);
     // https://stackoverflow.com/questions/1796510/accessing-a-python-traceback-from-the-c-api
     PyObject *err = PyErr_Occurred(); // do not Py_DECREF()
     if (err != NULL) {


### PR DESCRIPTION
* implement: send data to 3rd outlet from python
* fix: every script will be load as sub interpreter. it will divide environment when some nt.python objects load same script.
* tiny fix: post error when function doesn't return value (i.e. void function)

----

variable `maxobj` is added to module as like global variable implicitly.
`maxobj` has `outlet` method.

call:

```
    maxobj.outlet("hoge", 1, 2)
```

then [hoge 1 2] is output from 3rd outlet.